### PR TITLE
Grab apt key before adding repository

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get upgrade --yes
 RUN apt-get install --yes dialog apt-utils software-properties-common wget
 
 #Specifically add the Zandronum repo and install the application
-RUN apt-add-repository 'deb http://debian.drdteam.org stable multiverse'
 RUN wget -O - http://debian.drdteam.org/drdteam.gpg | apt-key add -
+RUN apt-add-repository 'deb https://debian.drdteam.org stable multiverse'
 RUN apt-get update --yes 
 RUN apt-get upgrade --yes
 RUN apt-get install --yes --quiet libsdl-image1.2 zandronum 


### PR DESCRIPTION
I was unable to build image with previous ordering. Got: 
```
=> CACHED [ 5/18] RUN apt-get install --yes dialog apt-utils software-properties-common   0.0s
 => ERROR [ 6/18] RUN apt-add-repository 'deb http://debian.drdteam.org stable multiverse  2.5s
------
 > [ 6/18] RUN apt-add-repository 'deb http://debian.drdteam.org stable multiverse':
#9 0.823 Hit:1 http://security.ubuntu.com/ubuntu focal-security InRelease
#9 0.823 Get:2 http://debian.drdteam.org stable InRelease [2966 B]
#9 0.932 Hit:3 http://archive.ubuntu.com/ubuntu focal InRelease
#9 1.016 Hit:4 http://archive.ubuntu.com/ubuntu focal-updates InRelease
#9 1.065 Err:2 http://debian.drdteam.org stable InRelease
#9 1.065   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 392203ABAF88540B
#9 1.101 Hit:5 http://archive.ubuntu.com/ubuntu focal-backports InRelease
#9 1.453 Reading package lists...
#9 2.504 W: GPG error: http://debian.drdteam.org stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 392203ABAF88540B
#9 2.504 E: The repository 'http://debian.drdteam.org stable InRelease' is not signed.
------
executor failed running [/bin/sh -c apt-add-repository 'deb http://debian.drdteam.org stable multiverse']: exit code: 100
```

Looking at the [repo website](http://debian.drdteam.org/), it looks like this is the recommended order